### PR TITLE
Make the plugin build with warnings as errors and without unity build

### DIFF
--- a/Plugins/ElgEditorScripting/Source/ElgEditorScripting/Private/Blueprints/ElgEditorBP_Editor.cpp
+++ b/Plugins/ElgEditorScripting/Source/ElgEditorScripting/Private/Blueprints/ElgEditorBP_Editor.cpp
@@ -6,6 +6,7 @@
 #include "ElgEditorBP_Enum.h"
 #include "HAL/FileManager.h"
 #include "Misc/FileHelper.h"
+#include "ElgEditorScripting.h"
 #include "ElgEditorContext_SlowTask.h"
 
 

--- a/Plugins/ElgEditorScripting/Source/ElgEditorScripting/Private/Blueprints/ElgEditorBP_UBlueprint.cpp
+++ b/Plugins/ElgEditorScripting/Source/ElgEditorScripting/Private/Blueprints/ElgEditorBP_UBlueprint.cpp
@@ -40,9 +40,10 @@ UBlueprint* UElgEditorBP_UBlueprint::GetBlueprintFromAssetData(const FAssetData&
 	Branches = EBPEditorOutputValidBranch::Valid;
 	return blueprint;
 
-#endif
+#else
 
 	return nullptr;
+#endif
 }
 
 
@@ -61,9 +62,10 @@ UBlueprint* UElgEditorBP_UBlueprint::GetBlueprintFromObject(UObject* Object, EBP
 	Branches = EBPEditorOutputValidBranch::Valid;
 	return blueprint;
 
-#endif
+#elif 
 
 	return nullptr;
+#endif
 }
 
 

--- a/Plugins/ElgEditorScripting/Source/ElgEditorScripting/Private/EditorContexts/ElgEditorContext_BP.cpp
+++ b/Plugins/ElgEditorScripting/Source/ElgEditorScripting/Private/EditorContexts/ElgEditorContext_BP.cpp
@@ -21,8 +21,9 @@ UElgEditorContext_LevelEditor* UElgEditorContext_BP::GetLevelEditorContext()
 #if WITH_EDITOR
 	const FElgEditorScriptingModule& elgEditorScriptModule = FModuleManager::Get().LoadModuleChecked<FElgEditorScriptingModule>(TEXT("ElgEditorScripting"));
 	return elgEditorScriptModule.GetContextManager().GetLevelEditorContext();
-#endif
+#else 
 	return nullptr;
+#endif
 }
 
 
@@ -31,8 +32,9 @@ UElgEditorContext_AssetBrowser* UElgEditorContext_BP::GetAssetBrowserContext()
 #if WITH_EDITOR
 	const FElgEditorScriptingModule& elgEditorScriptModule = FModuleManager::Get().LoadModuleChecked<FElgEditorScriptingModule>(TEXT("ElgEditorScripting"));
 	return elgEditorScriptModule.GetContextManager().GetAssetBrowserContext();
-#endif
+#else
 	return nullptr;
+#endif
 }
 
 

--- a/Plugins/ElgEditorScripting/Source/ElgEditorScripting/Private/EditorContexts/ElgEditorContext_LevelEditor.cpp
+++ b/Plugins/ElgEditorScripting/Source/ElgEditorScripting/Private/EditorContexts/ElgEditorContext_LevelEditor.cpp
@@ -15,6 +15,8 @@
 #include <EditorModeManager.h>
 #include <EditorModeTools.h>
 
+#include "Engine/HitResult.h"
+
 
 #pragma region Setup
 
@@ -353,7 +355,7 @@ void UElgEditorContext_LevelEditor::GetMousePosition(bool& Success, FVector2D& P
 
 
 void UElgEditorContext_LevelEditor::GetMousePositionWorld(const bool ShowTrace, bool& Success, FVector& WorldPos)
-{
+{ 
 	FHitResult Hit;
 	LineTrace(false, ShowTrace, TArray<AActor*>(), Success, Hit);
 


### PR DESCRIPTION
Added missing include files to define types properly. It luckily happens to work with unity builds, but we have a CI step which does static code analysis and doesn't use unity to catch missing include errors like this.

Also, the #endif that previously (correctly) was an #else causes an "unreachable code" error to appear since WITH_EDITOR will have two return statements after each other.